### PR TITLE
Mark hbck2 RPM as noarch

### DIFF
--- a/hbase-hbck2/bin/build.sh
+++ b/hbase-hbck2/bin/build.sh
@@ -44,6 +44,7 @@ fpm \
   --name $NAME \
   --version ${VERSION} \
   --iteration "${ITERATION}" \
+  --architecture all \
   -s "dir" \
   -t "rpm" \
   --package $RPMS_OUTPUT_DIR \


### PR DESCRIPTION
This RPM contains pure Java classes, there is no reason it can't run on any architecture