### PR TITLE
Use a newer parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>23</version>
+    <version>30</version>
     <relativePath/>
     <!-- no parent resolution -->
   </parent>


### PR DESCRIPTION
This fixes build failures we're having that appear caused by conflicting `httpclient` JARs on the maven classpath. Upstream is still on version 23, so just merging in upstream won't work here.